### PR TITLE
Fix: Resolve ProximityChatRoom and ChatRoom Incompatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,15 @@
         "@types/send": "*"
       }
     },
+    "back/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "back/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1306,6 +1315,16 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "libs/map-editor/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "libs/map-editor/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1748,6 +1767,16 @@
         "typescript": "^5.7.2"
       }
     },
+    "libs/math-utils/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "libs/math-utils/node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -1779,6 +1808,16 @@
       "devDependencies": {
         "@types/node": "^18.7.17",
         "typescript": "^5.7.2"
+      }
+    },
+    "libs/messages/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "libs/messages/node_modules/rxjs": {
@@ -1894,6 +1933,16 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      }
+    },
+    "libs/shared-utils/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "libs/shared-utils/node_modules/argparse": {
@@ -2776,6 +2825,16 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      }
+    },
+    "libs/store-utils/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "libs/store-utils/node_modules/argparse": {
@@ -3824,6 +3883,16 @@
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
+      }
+    },
+    "map-storage/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "map-storage/node_modules/argparse": {
@@ -10790,13 +10859,19 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.120",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
-      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -30981,6 +31056,16 @@
         "@types/send": "*"
       }
     },
+    "play/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "play/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -32109,6 +32194,16 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "uploader/node_modules/@types/node": {
+      "version": "18.19.120",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "uploader/node_modules/@typescript-eslint/eslint-plugin": {
@@ -37009,11 +37104,18 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.19.120",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
-      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
+      },
+      "dependencies": {
+        "undici-types": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+          "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
+        }
       }
     },
     "@types/parse-json": {
@@ -38354,6 +38456,15 @@
           "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
           "dev": true
         },
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -38649,6 +38760,15 @@
         "typescript": "^5.7.2"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "typescript": {
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -38672,6 +38792,15 @@
         "zod": "^3.23.8"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "rxjs": {
           "version": "6.6.3",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
@@ -38737,6 +38866,15 @@
           "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
           "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "argparse": {
           "version": "2.0.1",
@@ -39226,6 +39364,15 @@
           "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
           "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "argparse": {
           "version": "2.0.1",
@@ -46371,6 +46518,15 @@
             "@types/node": "*"
           }
         },
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -53345,6 +53501,15 @@
             "@types/send": "*"
           }
         },
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "accepts": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -54102,6 +54267,14 @@
             "@types/send": "*"
           }
         },
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "accepts": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -54522,6 +54695,15 @@
           "dev": true,
           "requires": {
             "@types/node": "*"
+          }
+        },
+        "@types/node": {
+          "version": "18.19.120",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+          "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
           }
         },
         "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "vitest": "^3.2.4"
   },
   "scripts": {
-    "prepare": "husky install || echo 'Husky not found. Maybe you are installing only a subproject.'"
+    "prepare": "husky install || echo 'Husky not found. Maybe you are installing only a subproject.'",
+    "proto-all": "cd messages && npm run proto-all"
   },
   "workspaces": [
     "play",

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -132,7 +132,16 @@ export class ProximityChatRoom implements ChatRoom {
             });
     }
 
-    sendMessage(message: string, action: ChatMessageType = "proximity", broadcast = true, threadId?: string): void {
+    sendMessage(message: string, threadId?: string): void {
+        this.sendProximityMessage(message, "proximity", true, threadId);
+    }
+
+    sendProximityMessage(
+        message: string,
+        action: ChatMessageType = "proximity",
+        broadcast = true,
+        threadId?: string
+    ): void {
         // Create content message
         const newChatMessageContent = {
             body: message,
@@ -181,7 +190,7 @@ export class ProximityChatRoom implements ChatRoom {
     }
 
     private addIncomingUser(spaceUser: SpaceUserExtended): void {
-        this.sendMessage(get(LL).chat.timeLine.incoming({ userName: spaceUser.name }), "incoming", false);
+        this.sendProximityMessage(get(LL).chat.timeLine.incoming({ userName: spaceUser.name }), "incoming", false);
         /*const newChatUser = mapExtendedSpaceUserToChatUser(spaceUser);
 
         //if (userUuid === this._userUuid) return;
@@ -193,7 +202,7 @@ export class ProximityChatRoom implements ChatRoom {
     }
 
     private addOutcomingUser(spaceUser: SpaceUserExtended): void {
-        this.sendMessage(get(LL).chat.timeLine.outcoming({ userName: spaceUser.name }), "outcoming", false);
+        this.sendProximityMessage(get(LL).chat.timeLine.outcoming({ userName: spaceUser.name }), "outcoming", false);
         this.removeTypingUserbyID(spaceUser.spaceUserId.toString());
 
         /*this._connection.connectedUsers.update((users) => {
@@ -450,13 +459,17 @@ export class ProximityChatRoom implements ChatRoom {
 
         if (this.users) {
             if (this.users.size > 2) {
-                this.sendMessage(get(LL).chat.timeLine.youLeft(), "outcoming", false);
+                this.sendProximityMessage(get(LL).chat.timeLine.youLeft(), "outcoming", false);
             } else {
                 for (const user of this.users.values()) {
                     if (user.spaceUserId === this._spaceUserId) {
                         continue;
                     }
-                    this.sendMessage(get(LL).chat.timeLine.outcoming({ userName: user.name }), "outcoming", false);
+                    this.sendProximityMessage(
+                        get(LL).chat.timeLine.outcoming({ userName: user.name }),
+                        "outcoming",
+                        false
+                    );
                 }
             }
             this.typingMembers.set([]);


### PR DESCRIPTION
The sendMessage method in ProximityChatRoom had a different signature than the one in the ChatRoom interface, causing a type incompatibility.

This commit resolves the issue by:

- Creating a new `sendProximityMessage` method in `ProximityChatRoom` to handle the specific logic for sending proximity messages.
- Updating the `sendMessage` method in `ProximityChatRoom` to match the signature of the `ChatRoom` interface. The `sendMessage` method now calls `sendProximityMessage` with the default values.

This change ensures that `ProximityChatRoom` correctly implements the `ChatRoom` interface, resolving the type incompatibility issue.